### PR TITLE
Wrappers for conversions from duration types from the 'time' library

### DIFF
--- a/human-readable-duration.cabal
+++ b/human-readable-duration.cabal
@@ -27,6 +27,7 @@ library
   hs-source-dirs:      src
   exposed-modules:     Data.Duration
   build-depends:       base >= 4.7 && < 5
+                     , time >= 1.0
   default-language:    Haskell2010
 
 -- test-suite human-readable-duration-test

--- a/src/Data/Duration.hs
+++ b/src/Data/Duration.hs
@@ -1,5 +1,7 @@
 module Data.Duration
     ( humanReadableDuration
+    , humanReadableDiffTime
+    , humanReadableNominalDiffTime
     -- durations
     , ms
     , oneSecond
@@ -16,6 +18,7 @@ module Data.Duration
     , getYears
     ) where
 
+import Data.Time.Clock (DiffTime, NominalDiffTime)
 
 -- | `humanReadableDuration` take some time in micro-seconds and render a human readable duration.
 --
@@ -30,6 +33,21 @@ humanReadableDuration n
   | n < day    = let h  = getHours   n in if h  > 0 then show h  ++ " hours " ++ humanReadableDuration (n `rem` hour) else ""
   | n < year   = let d  = getDays    n in if d  > 0 then show d  ++ " days " ++ humanReadableDuration (n `rem` day) else ""
   | otherwise  = let y  = getYears   n in if y  > 0 then show y  ++ " years " ++ humanReadableDuration (n `rem` year) else ""
+
+-- | Give a human readable output of a `DiffTime` from the time library.
+humanReadableDiffTime :: DiffTime -> String
+humanReadableDiffTime = humanReadableDuration
+                      . round
+                      . (* (1e6 :: Double))
+                      . realToFrac
+
+-- | Give a human readable output of a `NominalDiffTime` from the time library.
+humanReadableNominalDiffTime :: NominalDiffTime -> String
+humanReadableNominalDiffTime = humanReadableDuration
+                             . round
+                             . (* (1e6 :: Double))
+                             . realToFrac
+
 
 --------------------------------------------------------------------------------
 -- Durations


### PR DESCRIPTION
Added simple wrappers for conversions from the duration types that the "time" library (the canonical time library in Haskell), in case you wanted them.

This does incur a dependency on a new library, `time`; however, `time` _does_ come "built in" to GHC and is always installed in all but exceptional circumstances.  But, if this is against the spirit of the library, or if you think it clutters up the API, feel free to close and move on :)
